### PR TITLE
Make msgpack.unpacking utf8-clean, run oxstash bulk indexing in a loop

### DIFF
--- a/bin/oxstash
+++ b/bin/oxstash
@@ -121,17 +121,22 @@ def main():
         out_stream = blueox.client.stdin_stream()
 
     action_callback = functools.partial(build_doc, options)
-    bulk_streamer = elasticsearch.helpers.streaming_bulk(
-        es, out_stream,
-        request_timeout=options.request_timeout,
-        chunk_size=options.chunk_size,
-        expand_action_callback=action_callback)
 
-    for result in bulk_streamer:
-        batch_ok, item = result
-        if not item['index']['created']:
-            print item
+    while True:
+        try:
+            bulk_streamer = elasticsearch.helpers.streaming_bulk(
+                es, out_stream,
+                request_timeout=options.request_timeout,
+                chunk_size=options.chunk_size,
+                expand_action_callback=action_callback)
 
+            for result in bulk_streamer:
+                batch_ok, item = result
+                if not item['index']['created']:
+                    print item
+        except Exception as e:
+            print e
+            pass
 
 if __name__ == '__main__':
     try:

--- a/blueox/client.py
+++ b/blueox/client.py
@@ -113,7 +113,7 @@ def subscribe_stream(control_host, subscribe):
                 if not prefix and subscription and channel != subscription:
                     continue
 
-                yield msgpack.unpackb(data)
+                yield msgpack.unpackb(data,encoding='utf8')
             else:
                 break
 


### PR DESCRIPTION

Previously, any exception in the bulk indexing part of oxstash resulted in immediate
crash; upstart would pick it up normally but it's suboptimal.  Another source of crashes
was sending ascii-encoded utf8 strings, elasticsearch doesn't like it.