### PR TITLE
Fix DeprecationWarning: integer argument expected

### DIFF
--- a/blueox/context.py
+++ b/blueox/context.py
@@ -114,7 +114,7 @@ class Context(object):
             # Generate an id if one wasn't provided and we don't have any parents
             # We're going to encode the time as the front 4 bytes so we have some order to the ids
             # that could prove useful later on by making sorting a little easier.
-            self.id = (struct.pack(">L", time.time()) + os.urandom(12)).encode(
+            self.id = (struct.pack(">L", int(time.time())) + os.urandom(12)).encode(
                 'hex')
 
         if parent_ctx and not parent_ctx.enabled:


### PR DESCRIPTION
```
lib/python2.7/site-packages/blueox/context.py:117: DeprecationWarning: integer argument expected, got float
  self.id = (struct.pack(">L", time.time()) + os.urandom(12)).encode(
```